### PR TITLE
updated npm packages and command bot presence modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Node.js version **≥16.9.0** is required
       <td><a href="https://www.npmjs.com/package/mathjs">mathjs@11.0.1</a></td>
     </tr>
     <tr>
-      <td><a href="https://www.npmjs.com/package/discord.js">discord.js@14.1.2</a></td>
+      <td><a href="https://www.npmjs.com/package/discord.js">discord.js@14.2.0</a></td>
       <td><a href="https://www.npmjs.com/package/node-fetch">node-fetch@2.6.7</a></td>
     </tr>
     <tr>

--- a/commands/botpresence.js
+++ b/commands/botpresence.js
@@ -26,10 +26,10 @@ module.exports = {
 
             let streamLink = interaction.options.getString('link');
             let resultLink = streamLink;
-                    if (!streamLink || !streamLink.includes("youtube.") && !streamLink.includes("twitch.")) { 
-                        resultLink = "None"; 
+                    if (!streamLink || !streamLink.includes("youtube.") && !streamLink.includes("twitch.")) {
+                        resultLink = "None";
                         streamLink = "https://www.twitch.tv/discord";
-                    };
+                    }
 
             const statusField = interaction.options.getString('status');
             let resultStatus;

--- a/commands/botpresence.js
+++ b/commands/botpresence.js
@@ -24,9 +24,12 @@ module.exports = {
                     if (typeField === 'Competing') resultType = ActivityType.Competing;
                     if (typeField === 'Streaming') resultType = ActivityType.Streaming;
 
-            let streamLink = interaction.options.getString('link')
+            let streamLink = interaction.options.getString('link');
             let resultLink = streamLink;
-                    if (!streamLink || !streamLink.includes("youtube.com") && !streamLink.includes("twitch.tv")) { resultLink = "None"; streamLink = "https://www.twitch.tv/discord"};
+                    if (!streamLink || !streamLink.includes("youtube.") && !streamLink.includes("twitch.")) { 
+                        resultLink = "None"; 
+                        streamLink = "https://www.twitch.tv/discord";
+                    };
 
             const statusField = interaction.options.getString('status');
             let resultStatus;

--- a/commands/botpresence.js
+++ b/commands/botpresence.js
@@ -6,25 +6,30 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName('botpresence')
         .setDescription('Change bot\'s current presence in every server')
+        .addStringOption(option => option.setName('type').setDescription('Select a type').addChoices({ name: 'Playing', value: 'Playing' }, { name: 'Listening', value: 'Listening' }, { name: 'Watching', value: 'Watching' }, { name: 'Competing', value: 'Competing' }, { name: 'Streaming', value: 'Streaming' }).setRequired(true))
         .addStringOption(option => option.setName('activity').setDescription('Enter an activity').setRequired(true))
-        .addStringOption(option => option.setName('type').setDescription('Select a type').addChoices({ name: 'Playing', value: 'Playing' }, { name: 'Listening', value: 'Listening' }, { name: 'Watching', value: 'Watching' }, { name: 'Competing', value: 'Competing' }).setRequired(true))
-        .addStringOption(option => option.setName('status').setDescription('Select a status').addChoices({ name: 'Online', value: 'online' }, { name: 'Idle', value: 'idle' }, { name: 'Do Not Disturb', value: 'dnd' }, { name: 'Invisible', value: 'invisible' }).setRequired(true)),
+        .addStringOption(option => option.setName('status').setDescription('Select a status').addChoices({ name: 'Online', value: 'online' }, { name: 'Idle', value: 'idle' }, { name: 'Do Not Disturb', value: 'dnd' }, { name: 'Invisible', value: 'invisible' }).setRequired(true))
+        .addStringOption(option => option.setName('link').setDescription('Enter the stream link (only necessary in streaming)')),
     cooldown: '25',
     guildOnly: true,
     execute (interaction, configuration) {
         if (!interaction.member.permissions.has('Administrator')) return interaction.reply({ embeds: [errors[3]] });
-
             const activityField = interaction.options.getString('activity');
 
             const typeField = interaction.options.getString('type');
+            let resultType;
                     if (typeField === 'Playing') resultType = ActivityType.Playing;
                     if (typeField === 'Listening') resultType = ActivityType.Listening;
                     if (typeField === 'Watching') resultType = ActivityType.Watching;
                     if (typeField === 'Competing') resultType = ActivityType.Competing;
+                    if (typeField === 'Streaming') resultType = ActivityType.Streaming;
+
+            let streamLink = interaction.options.getString('link')
+            let resultLink = streamLink;
+                    if (!streamLink || !streamLink.includes("youtube.com") && !streamLink.includes("twitch.tv")) { resultLink = "None"; streamLink = "https://www.twitch.tv/discord"};
 
             const statusField = interaction.options.getString('status');
-
-                let resultStatus;
+            let resultStatus;
                     if (statusField === 'online') resultStatus = 'Online';
                     if (statusField === 'idle') resultStatus = 'Idle';
                     if (statusField === 'dnd') resultStatus = 'Do Not Disturb';
@@ -35,11 +40,12 @@ module.exports = {
                 .addFields(
                     { name: 'Activity', value: `${activityField}` },
                     { name: 'Type', value: `\`${typeField}\``, inline: true },
-                    { name: 'Status', value: `\`${resultStatus}\``, inline: true }
+                    { name: 'Status', value: `\`${resultStatus}\``, inline: true },
+                    { name: 'Stream Link', value: `\`${resultLink}\``, inline: true }
                 )
                 .setColor(configuration.embedColor);
 
-            interaction.client.user.setPresence({ activities: [{ name: `${activityField}`, type: resultType }], status: `${statusField}` });
+            interaction.client.user.setPresence({ activities: [{ name: `${activityField}`, type: resultType, url: streamLink }], status: `${statusField}` });
                 interaction.reply({ embeds: [embed] });
         }
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "discord-api-types": "^0.37.1",
-    "discord.js": "^14.1.2",
+    "discord.js": "^14.2.0",
     "dotenv": "^16.0.1",
     "eslint": "^8.21.0",
     "mathjs": "^11.0.1",


### PR DESCRIPTION
Hi @yewshanooi , in this commit I updated the **npm Discord.js** and modified the `botpresence.js` file, specifically added **streaming presence**, I would also like to categorize commands into subfolders though, _can I add it?_ 
I ask because in most repositories it is organized that way, it can be very repetitive but it also looks much better

Example:
![image](https://user-images.githubusercontent.com/84603580/184047491-3319ee0b-e386-4885-9c29-e080f330c1fb.png)
### Thank you, I await your response
